### PR TITLE
Add React snapshot test with frozen date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
+
+# Node.js
+node_modules/
+react-time-example/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Hackinstagram
+
+This repository includes a minimal React example with snapshot testing. The `react-time-example` folder contains the component and tests.
+
+## Running the React tests
+
+1. Install Node dependencies (requires internet access):
+   ```bash
+   cd react-time-example
+   npm install
+   ```
+
+2. Execute the tests:
+   ```bash
+   npm test
+   ```
+
+The tests use Jest with fake timers to freeze `Date.now()` so that snapshots remain stable across test runs.

--- a/react-time-example/__tests__/TimeDisplay.test.jsx
+++ b/react-time-example/__tests__/TimeDisplay.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import TimeDisplay from '../src/TimeDisplay';
+
+describe('TimeDisplay', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<TimeDisplay />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/react-time-example/jest.config.js
+++ b/react-time-example/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jsdom',
+};

--- a/react-time-example/jest.setup.js
+++ b/react-time-example/jest.setup.js
@@ -1,0 +1,9 @@
+beforeAll(() => {
+  // Freeze time so snapshots are stable
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2023-01-01T00:00:00Z'));
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});

--- a/react-time-example/package.json
+++ b/react-time-example/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-time-example",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^13.4.0",
+    "jest": "^29.0.0",
+    "babel-jest": "^29.0.0",
+    "@babel/preset-env": "^7.20.0",
+    "@babel/preset-react": "^7.20.0"
+  },
+  "jest": {
+    "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"],
+    "testEnvironment": "jsdom"
+  },
+  "babel": {
+    "presets": ["@babel/preset-env", "@babel/preset-react"]
+  }
+}

--- a/react-time-example/src/TimeDisplay.jsx
+++ b/react-time-example/src/TimeDisplay.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export default function TimeDisplay() {
+  const now = new Date(Date.now()).toLocaleString();
+  return <div data-testid="time-display">{now}</div>;
+}


### PR DESCRIPTION
## Summary
- create `TimeDisplay` component to render current date/time
- add `TimeDisplay.test.jsx` with snapshot testing using @testing-library/react
- configure Jest and setup file to freeze `Date.now()` via fake timers
- include minimal `package.json` for dependencies
- document test instructions and ignore `node_modules`

## Testing
- `npm install --silent` *(fails: registry access blocked)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1600833083329f882866a272a369